### PR TITLE
Add multi-domain support to Roundcube Helm chart

### DIFF
--- a/charts/roundcube/README.md.gotmpl
+++ b/charts/roundcube/README.md.gotmpl
@@ -137,6 +137,50 @@ roundcube:
     // Additional custom configuration
 ```
 
+### Multi-Domain Support
+
+Roundcube can serve multiple domains with completely different configurations:
+
+```yaml
+roundcube:
+  multiDomain:
+    enabled: true
+    domains:
+      - name: "mail.example.com"
+        config: |
+          $config['default_host'] = 'ssl://imap.example.com:993';
+          $config['smtp_server'] = 'tls://smtp.example.com:587';
+          $config['managesieve_host'] = 'imap.example.com';
+          $config['managesieve_port'] = 4190;
+          $config['plugins'] = array('managesieve', 'password', 'archive');
+      - name: "mail.company.org"
+        config: |
+          $config['default_host'] = 'ssl://mail.company.org:993';
+          $config['smtp_server'] = 'ssl://mail.company.org:465';
+          $config['smtp_conn_options'] = array(
+            'ssl' => array('verify_peer' => false)
+          );
+          $config['password_algorithm'] = 'sha256-crypt';
+          $config['password_db_dsn'] = 'mysql://user:pass@localhost/users';
+          $config['plugins'] = array('password', 'vacation', 'forward');
+
+ingress:
+  enabled: true
+  hosts:
+    - host: mail.example.com
+      paths:
+        - path: /
+    - host: mail.company.org
+      paths:
+        - path: /
+```
+
+With this configuration:
+- Each domain can have **completely different** settings
+- Full control over IMAP, SMTP, ManageSieve, OAuth, plugins, etc.
+- Users accessing different domains get their specific configuration
+- Fallback to default settings if domain is not configured
+
 {{ template "chart.maintainersSection" . }}
 
 {{ template "chart.sourcesSection" . }}

--- a/charts/roundcube/ci/multi-domain-values.yaml
+++ b/charts/roundcube/ci/multi-domain-values.yaml
@@ -1,0 +1,65 @@
+# Test values for Multi-Domain setup
+roundcube:
+  multiDomain:
+    enabled: true
+    domains:
+      - name: "mail.example.com"
+        config: |
+          $config['default_host'] = 'ssl://imap.example.com:993';
+          $config['smtp_server'] = 'tls://smtp.example.com:587';
+          $config['managesieve_host'] = 'imap.example.com';
+          $config['managesieve_port'] = 4190;
+          $config['managesieve_usetls'] = true;
+          $config['plugins'] = array('archive', 'zipdownload', 'managesieve');
+      - name: "mail.company.org"
+        config: |
+          $config['default_host'] = 'ssl://mail.company.org:993';
+          $config['smtp_server'] = 'tls://mail.company.org:587';
+          $config['smtp_port'] = 465;
+          $config['smtp_conn_options'] = array(
+            'ssl' => array(
+              'verify_peer' => false,
+              'verify_peer_name' => false,
+            ),
+          );
+          $config['password_algorithm'] = 'sha256-crypt';
+          $config['plugins'] = array('archive', 'zipdownload', 'password');
+      - name: "webmail.internal.local"
+        config: |
+          $config['default_host'] = 'ssl://mailserver.internal.local:993';
+          $config['smtp_server'] = 'tls://mailserver.internal.local:587';
+          $config['ldap_public'] = array(
+            'Addressbook' => array(
+              'hosts' => array('ldap.internal.local'),
+              'base_dn' => 'ou=users,dc=internal,dc=local',
+              'bind_dn' => 'cn=roundcube,dc=internal,dc=local',
+            ),
+          );
+          $config['plugins'] = array('archive', 'zipdownload', 'ldap_addressbook');
+  # Fallback configuration
+  defaultHost: "ssl://imap.example.com"
+  smtpServer: "tls://smtp.example.com"
+
+database:
+  type: sqlite
+
+persistence:
+  enabled: true
+  size: 1Gi
+
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: mail.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+    - host: mail.company.org
+      paths:
+        - path: /
+          pathType: Prefix
+    - host: webmail.internal.local
+      paths:
+        - path: /
+          pathType: Prefix

--- a/charts/roundcube/templates/configmap.yaml
+++ b/charts/roundcube/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.roundcube.customConfig }}
+{{- if or .Values.roundcube.customConfig .Values.roundcube.multiDomain.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,5 +7,43 @@ metadata:
     {{- include "roundcube.labels" . | nindent 4 }}
 data:
   config.inc.php: |
+{{- if .Values.roundcube.multiDomain.enabled }}
+    <?php
+    // Multi-domain configuration
+    // This allows different settings per domain
+    
+    // Default configuration (fallback)
+    $config['default_host'] = '{{ .Values.roundcube.defaultHost }}';
+    $config['smtp_server'] = '{{ .Values.roundcube.smtpServer }}';
+    $config['smtp_port'] = {{ .Values.roundcube.smtpPort }};
+    $config['smtp_user'] = '{{ .Values.roundcube.smtpUser }}';
+    $config['smtp_pass'] = '{{ .Values.roundcube.smtpPass }}';
+    
+    // Get current host
+    $current_host = $_SERVER['HTTP_HOST'] ?? '';
+    
+    // Per-domain configuration
+    switch($current_host) {
+    {{- range .Values.roundcube.multiDomain.domains }}
+        case '{{ .name }}':
+        case 'www.{{ .name }}':
+            // Configuration for {{ .name }}
+{{ .config | indent 12 }}
+            break;
+    {{- end }}
+        default:
+            // Use default configuration
+            break;
+    }
+    
+    // Common settings for all domains (can be overridden above)
+    if (!isset($config['smtp_user'])) {
+        $config['smtp_user'] = '%u';
+    }
+    if (!isset($config['smtp_pass'])) {
+        $config['smtp_pass'] = '%p';
+    }
+{{- else }}
 {{ .Values.roundcube.customConfig | indent 4 }}
+{{- end }}
 {{- end }}

--- a/charts/roundcube/templates/deployment.yaml
+++ b/charts/roundcube/templates/deployment.yaml
@@ -160,7 +160,7 @@ spec:
             - name: logs
               mountPath: {{ .Values.persistence.logsPath }}
             {{- end }}
-            {{- if .Values.roundcube.customConfig }}
+            {{- if or .Values.roundcube.customConfig .Values.roundcube.multiDomain.enabled }}
             - name: custom-config
               mountPath: /var/roundcube/config/config.inc.php
               subPath: config.inc.php
@@ -183,7 +183,7 @@ spec:
         - name: logs
           emptyDir: {}
         {{- end }}
-        {{- if .Values.roundcube.customConfig }}
+        {{- if or .Values.roundcube.customConfig .Values.roundcube.multiDomain.enabled }}
         - name: custom-config
           configMap:
             name: {{ include "roundcube.fullname" . }}-custom

--- a/charts/roundcube/values.yaml
+++ b/charts/roundcube/values.yaml
@@ -158,6 +158,27 @@ roundcube:
   extraVolumes: []
   # Custom configuration (will be mounted as config.inc.php)
   customConfig: ""
+  # Multi-domain configuration (simplified setup for multiple IMAP servers)
+  # When enabled, will auto-generate config for multiple domains
+  multiDomain:
+    enabled: false
+    # List of domain configurations
+    domains: []
+    # Example:
+    # - name: "example.com"
+    #   config: |
+    #     $config['default_host'] = 'ssl://imap.example.com:993';
+    #     $config['smtp_server'] = 'tls://smtp.example.com:587';
+    #     $config['managesieve_host'] = 'tls://imap.example.com:4190';
+    #     $config['managesieve_usetls'] = true;
+    # - name: "company.org"  
+    #   config: |
+    #     $config['default_host'] = 'ssl://mail.company.org:993';
+    #     $config['smtp_server'] = 'tls://mail.company.org:587';
+    #     $config['managesieve_host'] = 'mail.company.org';
+    #     $config['managesieve_port'] = 4190;
+    #     $config['password_algorithm'] = 'sha256-crypt';
+    #     $config['password_db_dsn'] = 'mysql://user:pass@localhost/postfix';
   # DES key for encryption (auto-generated if not set)
   desKey: ""
 


### PR DESCRIPTION
- Introduce `multiDomain` configuration for serving multiple domains with unique settings
- Update ConfigMap, Deployment, and README to support multi-domain capabilities
- Provide example values and test configuration for multi-domain setup