### PR TITLE
docs: add Discord community links to README and CONTRIBUTING files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,14 @@ We love your input! We want to make contributing to this project as easy and tra
 - Proposing new features
 - Becoming a maintainer
 
+## Getting Help
+
+Before you start contributing, feel free to reach out:
+
+- **Discord**: Join our [Discord Server](https://discord.gg/6WWWrhFVf3) to chat with maintainers and get quick help
+- **Discussions**: Use [GitHub Discussions](https://github.com/encircle360-oss/helm-charts/discussions) for questions
+- **Issues**: Search [existing issues](https://github.com/encircle360-oss/helm-charts/issues) or create a new one
+
 ## Development Process
 
 We use GitHub to host code, to track issues and feature requests, as well as accept pull requests.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Release Charts](https://github.com/encircle360-oss/helm-charts/actions/workflows/release.yaml/badge.svg)](https://github.com/encircle360-oss/helm-charts/actions/workflows/release.yaml)
 [![Deploy Documentation](https://github.com/encircle360-oss/helm-charts/actions/workflows/pages.yaml/badge.svg)](https://github.com/encircle360-oss/helm-charts/actions/workflows/pages.yaml)
+[![Discord](https://img.shields.io/badge/Discord-Join%20Chat-7289da?logo=discord&logoColor=white)](https://discord.gg/6WWWrhFVf3)
 
 A collection of Helm charts for various open-source applications, maintained and sponsored by [encircle360 GmbH](https://encircle360.com) together with the open source community, partners and friends.
 
@@ -101,6 +102,7 @@ We believe in community-driven development and are happy to share maintainer res
 
 ### Community Support
 
+- **Discord Community**: Join our [Discord Server](https://discord.gg/6WWWrhFVf3) to chat with maintainers and other users
 - **Chart Issues**: Create an [Issue](https://github.com/encircle360-oss/helm-charts/issues) for Helm chart bugs and feature requests
 - **General Questions**: Start a [Discussion](https://github.com/encircle360-oss/helm-charts/discussions) for questions and general support
 - **Application Bugs**: For bugs within the applications themselves (not chart-related), please report them to the respective upstream project:


### PR DESCRIPTION
- Include Discord badge in README.
- Highlight Discord as a support channel in contributing guidelines.