### PR TITLE
fix(ci): stop helm-docs install from clobbering repo LICENSE/README.md

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -51,9 +51,12 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         continue-on-error: true
         run: |
-          # Install helm-docs
-          curl -sSL https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_x86_64.tar.gz | tar -xz
-          sudo mv helm-docs /usr/local/bin/
+          # Install helm-docs — extract into /tmp because the tarball
+          # ships LICENSE / README.md / CHANGELOG.md at its root and
+          # would otherwise clobber the repo's own files.
+          curl -sSL https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_x86_64.tar.gz \
+            | tar -xz -C /tmp helm-docs
+          sudo mv /tmp/helm-docs /usr/local/bin/
 
           # Check if documentation is up to date
           helm-docs --chart-search-root=charts

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -41,9 +41,12 @@ jobs:
 
       - name: Install helm-docs
         run: |
-          wget https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_x86_64.tar.gz
-          tar -xzf helm-docs_1.14.2_Linux_x86_64.tar.gz
-          sudo mv helm-docs /usr/local/bin/
+          # Extract into /tmp, NOT into the repo — the release tarball
+          # ships LICENSE / README.md / CHANGELOG.md at its root and
+          # would clobber the equally-named files in this repo.
+          wget -qO /tmp/helm-docs.tar.gz https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_x86_64.tar.gz
+          tar -xzf /tmp/helm-docs.tar.gz -C /tmp helm-docs
+          sudo mv /tmp/helm-docs /usr/local/bin/
           helm-docs --version
 
       - name: Generate Chart README files and copy to docs

--- a/.github/workflows/sync-readmes.yaml
+++ b/.github/workflows/sync-readmes.yaml
@@ -42,20 +42,35 @@ jobs:
 
       - name: Install helm-docs
         run: |
-          curl -sSL https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_x86_64.tar.gz | tar -xz
-          sudo mv helm-docs /usr/local/bin/
+          # Extract into /tmp, NOT into the repo. The release tarball
+          # contains LICENSE / README.md / CHANGELOG.md at its root, and
+          # a previous version of this step streamed it into the repo
+          # root with `tar -xz`, silently clobbering the actual project
+          # LICENSE/README.md and dropping a stray CHANGELOG.md — which
+          # then made `git status --porcelain` non-empty on every run.
+          curl -sSL https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_x86_64.tar.gz \
+            | tar -xz -C /tmp helm-docs
+          sudo mv /tmp/helm-docs /usr/local/bin/
 
       - name: Regenerate READMEs
         run: helm-docs --chart-search-root=charts
 
       - name: Commit + push drift, if any
         run: |
-          if [ -z "$(git status --porcelain)" ]; then
+          # Only react to drift inside charts/ — any other workspace
+          # changes (e.g. workflow scratch files) are deliberately
+          # ignored. `git add charts/` below is the source of truth for
+          # what we ever try to commit.
+          if [ -z "$(git status --porcelain -- charts/)" ]; then
             echo "No README drift — nothing to commit."
             exit 0
           fi
           git config user.name "encircle360-oss-bot"
           git config user.email "oss+bot@encircle360.com"
           git add charts/
+          if git diff --cached --quiet; then
+            echo "Drift was outside charts/ — nothing staged, nothing to commit."
+            exit 0
+          fi
           git commit -m "docs(charts): regenerate READMEs via helm-docs"
           git push origin main

--- a/.github/workflows/update-cdi.yaml
+++ b/.github/workflows/update-cdi.yaml
@@ -27,9 +27,12 @@ jobs:
           sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
           sudo chmod +x /usr/local/bin/yq
 
-          # helm-docs
-          curl -sSL https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_x86_64.tar.gz | tar -xz
-          sudo mv helm-docs /usr/local/bin/
+          # helm-docs — extract to /tmp to avoid clobbering the repo's
+          # LICENSE / README.md / CHANGELOG.md (which sit at the same
+          # paths inside the release tarball).
+          curl -sSL https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_x86_64.tar.gz \
+            | tar -xz -C /tmp helm-docs
+          sudo mv /tmp/helm-docs /usr/local/bin/
 
       - name: Get versions
         id: versions

--- a/.github/workflows/update-kubevirt.yaml
+++ b/.github/workflows/update-kubevirt.yaml
@@ -27,9 +27,12 @@ jobs:
           sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
           sudo chmod +x /usr/local/bin/yq
 
-          # helm-docs
-          curl -sSL https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_x86_64.tar.gz | tar -xz
-          sudo mv helm-docs /usr/local/bin/
+          # helm-docs — extract to /tmp to avoid clobbering the repo's
+          # LICENSE / README.md / CHANGELOG.md (which sit at the same
+          # paths inside the release tarball).
+          curl -sSL https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_x86_64.tar.gz \
+            | tar -xz -C /tmp helm-docs
+          sudo mv /tmp/helm-docs /usr/local/bin/
 
       - name: Get versions
         id: versions


### PR DESCRIPTION
## Why CI failed after #31 merged

The **Sync Chart READMEs** workflow ([run 27665942499](https://github.com/encircle360-oss/helm-charts/actions/runs/27665942499)) failed with:

```
modified:   LICENSE
modified:   README.md
Untracked files: CHANGELOG.md
...
nothing to commit, working tree clean
##[error]Process completed with exit code 1.
```

## Root cause

The helm-docs release tarball ships **LICENSE**, **README.md** and **CHANGELOG.md** at its root, next to the `helm-docs` binary:

```
$ curl -sSL .../helm-docs_1.14.2_Linux_x86_64.tar.gz | tar -tz
CHANGELOG.md
LICENSE
README.md
helm-docs
```

The install step in every helm-docs-using workflow streamed the archive into the workspace with `tar -xz`, which silently overwrote the repo's own `LICENSE` and `README.md` and dropped an untracked `CHANGELOG.md`. The Sync workflow then saw those files as drift, took the "there is drift" branch, `git add charts/` staged nothing, and `git commit` exited non-zero with "nothing to commit".

The other workflows masked the bug because they either reset the workspace before pushing (`pages.yaml`) or only ever staged `charts/`.

## Fix

1. Extract only the binary into `/tmp`:
    ```
    tar -xz -C /tmp helm-docs
    ```
   GNU tar (Linux runners) treats the trailing filename as a member filter, so the docs files in the tarball stay unpacked. `/tmp` is always-clean on GitHub-hosted runners. Verified on `alpine:3.20`.

2. In `sync-readmes.yaml`, guard the commit step twice: scope the drift check to `-- charts/` and bail again if nothing ended up staged. Defense in depth in case a future helm-docs invocation touches something outside `charts/`.

## Files touched

- `.github/workflows/sync-readmes.yaml`
- `.github/workflows/pages.yaml`
- `.github/workflows/lint.yaml`
- `.github/workflows/update-cdi.yaml`
- `.github/workflows/update-kubevirt.yaml`

## Test plan

- [ ] CI on this PR runs `lint` and shows no LICENSE/README.md drift in `git status` during the documentation-check step.
- [ ] After merge, `Sync Chart READMEs` workflow on `main` exits cleanly (either "No README drift" or "nothing staged" — both are 0).